### PR TITLE
LFLT-480 Update dependencies of Leaflet stack components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   build_leaflet-rest-api:
     docker:
-      - image: cimg/openjdk:11.0.12
+      - image: cimg/openjdk:11.0
     steps:
       - checkout
       - run:

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>leaflet-rest-api</artifactId>
-    <version>1.6.9</version>
+    <version>1.6.10</version>
 
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>1.0-r2110.1</version>
+        <version>2.0-r2208.1</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
 - Changed CircleCI build image version
 - Updated Leaflet Stack Base BOM version to 2.0-r2208.1
 - Bumped version to 1.6.10